### PR TITLE
Make all integer types implicit instances of S

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Main workflow
+
+on:
+  pull_request:
+  push:
+  schedule:
+    # Prime the caches every Monday
+    - cron: 0 1 * * MON
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        ocaml-compiler:
+          - 4.12.x
+          - 4.11.x
+          - 4.10.x
+          - 4.09.x
+          - 4.08.x
+          - 4.07.x
+          - 4.06.x
+          - 4.05.x
+          - 4.04.x
+          - 4.03.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - run: opam install . --deps-only --with-test
+
+      - run: opam exec -- dune build
+
+      - run: opam exec -- dune runtest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,39 +6,18 @@ on:
   - workflow_dispatch
 
 jobs:
-  build:
+  tests:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            ocaml-compiler: 4.03.x
-          - os: ubuntu-latest
-            ocaml-compiler: 4.04.x
-          - os: ubuntu-latest
-            ocaml-compiler: 4.05.x
-          - os: ubuntu-latest
-            ocaml-compiler: 4.06.x
-          - os: ubuntu-latest
-            ocaml-compiler: 4.07.x
-          - os: ubuntu-latest
-            ocaml-compiler: 4.08.x
-          - os: ubuntu-latest
-            ocaml-compiler: 4.09.x
-          - os: ubuntu-latest
-            ocaml-compiler: 4.10.x
-          - os: ubuntu-latest
-            ocaml-compiler: 4.11.x
-          - os: ubuntu-latest
-            ocaml-compiler: 4.12.x
-          - os: windows-latest
-            ocaml-compiler: 4.11.x
-          - os: windows-latest
-            ocaml-compiler: 4.12.x
-          - os: macos-latest
-            ocaml-compiler: 4.11.1
-          - os: macos-latest
-            ocaml-compiler: 4.12.x
+        os:
+          - ubuntu-latest
+          - windows-latest
+          # OCaml 4.02 doesn't work easily on ARM macOS
+          # - macos-latest
+        ocaml-compiler:
+          - ocaml-variants.4.02.1+modular-implicits
+          - ocaml-variants.4.02.1+modular-implicits-ber
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,21 +12,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-          - windows-latest
-        ocaml-compiler:
-          - 4.12.x
-          - 4.11.x
-          - 4.10.x
-          - 4.09.x
-          - 4.08.x
-          - 4.07.x
-          - 4.06.x
-          - 4.05.x
-          - 4.04.x
-          - 4.03.x
+        include:
+          - os: ubuntu-latest
+            ocaml-compiler: 4.03.x
+          - os: ubuntu-latest
+            ocaml-compiler: 4.04.x
+          - os: ubuntu-latest
+            ocaml-compiler: 4.05.x
+          - os: ubuntu-latest
+            ocaml-compiler: 4.06.x
+          - os: ubuntu-latest
+            ocaml-compiler: 4.07.x
+          - os: ubuntu-latest
+            ocaml-compiler: 4.08.x
+          - os: ubuntu-latest
+            ocaml-compiler: 4.09.x
+          - os: ubuntu-latest
+            ocaml-compiler: 4.10.x
+          - os: ubuntu-latest
+            ocaml-compiler: 4.11.x
+          - os: ubuntu-latest
+            ocaml-compiler: 4.12.x
+          - os: windows-latest
+            ocaml-compiler: 4.11.x
+          - os: windows-latest
+            ocaml-compiler: 4.12.x
+          - os: macos-latest
+            ocaml-compiler: 4.11.1
+          - os: macos-latest
+            ocaml-compiler: 4.12.x
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,9 @@
-name: Main workflow
+name: Integers
 
 on:
-  pull_request:
-  push:
-  schedule:
-    # Prime the caches every Monday
-    - cron: 0 1 * * MON
+  - pull_request
+  - push
+  - workflow_dispatch
 
 jobs:
   build:

--- a/src/signed.ml
+++ b/src/signed.ml
@@ -63,7 +63,7 @@ struct
   let (asr) = shift_right
 end
 
-module Int =
+implicit module Int =
 struct
   module Basics =
   struct
@@ -107,7 +107,7 @@ struct
   let pp fmt n = Format.fprintf fmt "%d" n
 end
 
-module Int32 = 
+implicit module Int32 =
 struct
   (* Int32.equal was introduced in OCaml 4.03.0 *)
   let equal (x:int32) (y:int32) = x = y [@@ocaml.warning "-32"]
@@ -122,7 +122,7 @@ struct
   let pp fmt n = Format.fprintf fmt "%ld" n
 end
 
-module Int64 = 
+implicit module Int64 =
 struct
   (* Int64.equal was introduced in OCaml 4.03.0 *)
   let equal (x:int64) (y:int64) = x = y [@@ocaml.warning "-32"]
@@ -145,9 +145,9 @@ let of_byte_size : int -> (module S) = function
   | 8 -> (module Int64)
   | _ -> invalid_arg "Signed.of_byte_size"
 
-module SInt = (val of_byte_size (int_size ()))
-module Long = (val of_byte_size (long_size ()))
-module LLong = (val of_byte_size (llong_size ()))
+implicit module SInt = (val of_byte_size (int_size ()))
+implicit module Long = (val of_byte_size (long_size ()))
+implicit module LLong = (val of_byte_size (llong_size ()))
 
 type sint = SInt.t
 type long = Long.t

--- a/src/signed.mli
+++ b/src/signed.mli
@@ -55,22 +55,22 @@ module type S = sig
 end
 (** Signed integer operations *)
 
-module Int : S with type t = int
+implicit module Int : S with type t = int
 (** Signed integer type and operations. *)
 
-module Int32 : S with type t = int32
+implicit module Int32 : S with type t = int32
 (** Signed 32-bit integer type and operations. *)
 
-module Int64 : S with type t = int64
+implicit module Int64 : S with type t = int64
 (** Signed 64-bit integer type and operations. *)
 
-module SInt : S
+implicit module SInt : S
 (** C's signed integer type and operations. *)
 
-module Long : S
+implicit module Long : S
 (** The signed long integer type and operations. *)
 
-module LLong : S
+implicit module LLong : S
 (** The signed long long integer type and operations. *)
 
 type sint = SInt.t

--- a/src/unsigned.ml
+++ b/src/unsigned.ml
@@ -105,7 +105,7 @@ struct
 end
 
 
-module UInt8 : S with type t = private int =
+implicit module UInt8 : S with type t = private int =
 struct
   module B =
   struct
@@ -136,7 +136,7 @@ struct
 end
 
 
-module UInt16 : S with type t = private int =
+implicit module UInt16 : S with type t = private int =
 struct
   module B =
   struct
@@ -167,7 +167,7 @@ struct
 end
 
 
-module UInt32 : sig
+implicit module UInt32 : sig
   include S
   external of_int32 : int32 -> t = "integers_uint32_of_int32"
   external to_int32 : t -> int32 = "integers_int32_of_uint32"
@@ -203,7 +203,7 @@ struct
 end
 
 
-module UInt64 : sig
+implicit module UInt64 : sig
   include S
   external of_int64 : int64 -> t = "integers_uint64_of_int64"
   external to_int64 : t -> int64 = "integers_uint64_to_int64"
@@ -255,12 +255,12 @@ external uint_size : unit -> int = "integers_uint_size"
 external ulong_size : unit -> int = "integers_ulong_size"
 external ulonglong_size : unit -> int = "integers_ulonglong_size"
 
-module Size_t : S = (val of_byte_size (size_t_size ()))
-module UChar = UInt8
-module UShort : S = (val of_byte_size (ushort_size ()))
-module UInt : S = (val of_byte_size (uint_size ()))
-module ULong : S = (val of_byte_size (ulong_size ()))
-module ULLong : S = (val of_byte_size (ulonglong_size ()))
+implicit module Size_t : S = (val of_byte_size (size_t_size ()))
+implicit module UChar = UInt8
+implicit module UShort : S = (val of_byte_size (ushort_size ()))
+implicit module UInt : S = (val of_byte_size (uint_size ()))
+implicit module ULong : S = (val of_byte_size (ulong_size ()))
+implicit module ULLong : S = (val of_byte_size (ulonglong_size ()))
 
 type uchar = UChar.t
 type uint8 = UInt8.t

--- a/src/unsigned.mli
+++ b/src/unsigned.mli
@@ -135,23 +135,23 @@ module type S = sig
 end
 (** Unsigned integer operations. *)
 
-module UChar : S with type t = private int
+implicit module UChar : S with type t = private int
 (** Unsigned char type and operations. *)
 
-module UInt8 : S with type t = private int
+implicit module UInt8 : S with type t = private int
 (** Unsigned 8-bit integer type and operations. *)
 
-module UInt16 : S with type t = private int
+implicit module UInt16 : S with type t = private int
 (** Unsigned 16-bit integer type and operations. *)
 
-module UInt32 : sig
+implicit module UInt32 : sig
   include S
   val of_int32 : int32 -> t
   val to_int32 : t -> int32
 end
 (** Unsigned 32-bit integer type and operations. *)
 
-module UInt64 : sig
+implicit module UInt64 : sig
   include S
   val of_int64 : int64 -> t
   val to_int64 : t -> int64
@@ -167,19 +167,19 @@ module UInt64 : sig
 end
 (** Unsigned 64-bit integer type and operations. *)
 
-module Size_t : S
+implicit module Size_t : S
 (** The size_t unsigned integer type and operations. *)
 
-module UShort : S
+implicit module UShort : S
 (** The unsigned short integer type and operations. *)
 
-module UInt : S
+implicit module UInt : S
 (** The unsigned int type and operations. *)
 
-module ULong : S
+implicit module ULong : S
 (** The unsigned long integer type and operations. *)
 
-module ULLong : S
+implicit module ULLong : S
 (** The unsigned long long integer type and operations. *)
 
 

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,4 @@
+(tests
+  (package integers)
+  (libraries integers)
+  (names implicits))

--- a/test/implicits.ml
+++ b/test/implicits.ml
@@ -1,0 +1,34 @@
+let () = print_endline "Implicit module resolution test"
+
+let () =
+  let square {S : Unsigned.S} x = S.Infix.(x * x) in
+  let open Unsigned in
+  assert (square (UInt8.of_int 5) = (UInt8.of_int 25));
+  assert (square (UInt16.of_int 5) = (UInt16.of_int 25));
+  assert (square (UInt32.of_int 5) = (UInt32.of_int 25));
+  assert (square (UInt64.of_int 5) = (UInt64.of_int 25));
+  assert (square (UChar.of_int 5) = (UChar.of_int 25));
+  assert (square (UShort.of_int 5) = (UShort.of_int 25));
+  assert (square (UInt.of_int 5) = (UInt.of_int 25));
+  assert (square (ULong.of_int 5) = (ULong.of_int 25));
+  assert (square (ULLong.of_int 5) = (ULLong.of_int 25));
+  assert (square (Size_t.of_int 5) = (Size_t.of_int 25))
+
+let () =
+  let square {S : Signed.S} x = S.Infix.(x * x) in
+  let open Signed in
+  assert (square (Int32.of_int 5) = (Int32.of_int 25));
+  assert (square (Int64.of_int 5) = (Int64.of_int 25));
+  assert (square (SInt.of_int 5) = (SInt.of_int 25));
+  assert (square (Long.of_int 5) = (Long.of_int 25));
+  assert (square (LLong.of_int 5) = (LLong.of_int 25))
+
+let () =
+  (* ensure signed types resolve as instances of unsigned's signature *)
+  let square {S : Unsigned.S} x = S.Infix.(x * x) in
+  let open Signed in
+  assert (square (Int32.of_int 5) = (Int32.of_int 25));
+  assert (square (Int64.of_int 5) = (Int64.of_int 25));
+  assert (square (SInt.of_int 5) = (SInt.of_int 25));
+  assert (square (Long.of_int 5) = (Long.of_int 25));
+  assert (square (LLong.of_int 5) = (LLong.of_int 25))


### PR DESCRIPTION
I had to slightly retrofit the tests, because the test suite wasn't added until after 0.4.0. The merge
conflicts with the [existing test suite](https://github.com/yallop/ocaml-integers/tree/6aaa3e3d6e9bd52e9afa433de38d8c69debc97eb/test) shouldn't be too bad.